### PR TITLE
source creds from more then shared config.

### DIFF
--- a/cmd/sesame/cmd/common.go
+++ b/cmd/sesame/cmd/common.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/spf13/cobra"
@@ -51,7 +50,6 @@ func (ssmCommand *SSMCommand) conf() {
 	config := &aws.Config{
 		Region:                        aws.String(getAwsRegion()),
 		CredentialsChainVerboseErrors: aws.Bool(true),
-		Credentials:                   credentials.NewSharedCredentials("", profile),
 	}
 
 	sess, err := session.NewSessionWithOptions(session.Options{


### PR DESCRIPTION
# Fixing error when run on EC2 Instance w/IAM Role Profile

```
trackomate called: [id=d3xxxxxdc]
AWS profile: [default]
UserHomeNotFound: user home directory not found.
```